### PR TITLE
add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,11 @@ RUN apt-get install python-pip -y
 RUN apt-get install python3 -y
 RUN apt-get install python3-pip -y
 
-# run two quick checks
 RUN python2
 RUN python3
 
 WORKDIR /calculator
 COPY * ./
 RUN pip install .
-# doesn't work
-# RUN pip3 install .
 
-ENTRYPOINT [ "python", "my_first_calculator.py" ]
+ENTRYPOINT ["python", "my_first_calculator.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:latest
+
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install python2.7 -y
+RUN apt-get install python-pip -y
+RUN apt-get install python3 -y
+RUN apt-get install python3-pip -y
+
+# run two quick checks
+RUN python2
+RUN python3
+
+WORKDIR /calculator
+COPY * ./
+RUN pip install .
+# doesn't work
+# RUN pip3 install .
+
+ENTRYPOINT [ "python", "my_first_calculator.py" ]


### PR DESCRIPTION
Use `docker build -t my_first_calculator.py .` to build the application.
Use `docker run -it my_first_calculator.py` to run the application.

The dockerfile was heavily optimized to use just the necessary storage space (currently 580MB).

Solves #95.